### PR TITLE
Fix iOS15 reload animations

### DIFF
--- a/Example/ChatLayout/Chat/Controller/Helpers/DifferenceKit+Extension.swift
+++ b/Example/ChatLayout/Chat/Controller/Helpers/DifferenceKit+Extension.swift
@@ -11,17 +11,17 @@ import DifferenceKit
 import Foundation
 import UIKit
 
-public extension UICollectionView {
+extension UICollectionView {
 
     func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         onInterruptedReload: (() -> Void)? = nil,
         completion: ((Bool) -> Void)? = nil,
-        setData: (C) -> Void
+        setData: ((C) -> Void)?
     ) {
         if case .none = window, let data = stagedChangeset.last?.data {
-            setData(data)
+            setData?(data)
             if let onInterruptedReload = onInterruptedReload {
                 onInterruptedReload()
             } else {
@@ -31,30 +31,21 @@ public extension UICollectionView {
             return
         }
 
-        let dispatchGroup: DispatchGroup? = completion != nil
-            ? DispatchGroup()
-            : nil
-        let completionHandler: ((Bool) -> Void)? = completion != nil
-            ? { _ in
-                dispatchGroup!.leave()
-            }
-            : nil
-
-        for changeset in stagedChangeset {
+        func perfomUpdate(changeset: Changeset<C>, performCompletion: ((Bool) -> Void)?) {
             if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
-                setData(data)
+                setData?(data)
                 if let onInterruptedReload = onInterruptedReload {
                     onInterruptedReload()
                 } else {
                     reloadData()
                 }
                 completion?(false)
+                performCompletion?(false)
                 return
             }
 
             performBatchUpdates({
-                setData(changeset.data)
-                dispatchGroup?.enter()
+                setData?(changeset.data)
 
                 if !changeset.sectionDeleted.isEmpty {
                     deleteSections(IndexSet(changeset.sectionDeleted))
@@ -93,10 +84,37 @@ public extension UICollectionView {
                 for (source, target) in changeset.elementMoved {
                     moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
                 }
-            }, completion: completionHandler)
+            }, completion: { result in performCompletion?(result) })
         }
-        dispatchGroup?.notify(queue: .main) {
-            completion!(true)
+
+        func performInSeries(stagedChangeset: StagedChangeset<C>) {
+            var stagedChangeset = stagedChangeset
+            if !stagedChangeset.isEmpty, let item = stagedChangeset.first {
+                stagedChangeset.removeFirst()
+                perfomUpdate(changeset: item) { result in
+                    guard result else { return }
+                    performInSeries(stagedChangeset: stagedChangeset)
+                }
+                return
+            }
+            completion?(true)
+        }
+
+        func perfomInConcurrency() {
+            let dispatchGroup: DispatchGroup? = completion != nil ? DispatchGroup() : nil
+            dispatchGroup?.notify(queue: .main) {
+                completion?(true)
+            }
+            for changeset in stagedChangeset {
+                dispatchGroup?.enter()
+                perfomUpdate(changeset: changeset) { result in dispatchGroup?.leave() }
+            }
+        }
+
+        if #available(iOS 15, *) {
+            performInSeries(stagedChangeset: stagedChangeset)
+        } else {
+            perfomInConcurrency()
         }
     }
 
@@ -110,13 +128,70 @@ extension StagedChangeset {
     // DifferenceKit.
     func flattenIfPossible() -> StagedChangeset {
         if count == 2,
-           self[0].sectionChangeCount == 0,
-           self[1].sectionChangeCount == 0,
-           self[0].elementDeleted.count == self[0].elementChangeCount,
-           self[1].elementInserted.count == self[1].elementChangeCount {
+            self[0].sectionChangeCount == 0,
+            self[1].sectionChangeCount == 0,
+            self[0].elementDeleted.count == self[0].elementChangeCount,
+            self[1].elementInserted.count == self[1].elementChangeCount {
             return StagedChangeset(arrayLiteral: Changeset(data: self[1].data, elementDeleted: self[0].elementDeleted, elementInserted: self[1].elementInserted))
         }
         return self
     }
 
+    func mergeChangesIfPossible() -> StagedChangeset {
+        if #available(iOS 15, *), var lastItem = self.last {
+            var stagedChangeset = self
+            let numberOfData = lastItem.data.count
+
+            let sectionDeleted = stagedChangeset.flatMap({ $0.sectionDeleted })
+            let sectionInserted = stagedChangeset.flatMap({ $0.sectionInserted })
+            let sectionUpdated = stagedChangeset.flatMap({ $0.sectionUpdated })
+            let sectionMoved = stagedChangeset.flatMap({ $0.sectionMoved })
+
+            var elementDeleted = stagedChangeset.flatMap({ $0.elementDeleted })
+            var elementInserted = stagedChangeset.flatMap({ $0.elementInserted })
+            let elementUpdated = stagedChangeset.flatMap({ $0.elementUpdated })
+            let elementMoved = stagedChangeset.flatMap({ $0.elementMoved })
+
+            guard sectionDeleted.count == 0, sectionInserted.count == 0, sectionUpdated.count == 0, sectionMoved.count == 0,
+                  !elementDeleted.map({ $0.element }).contains(where: { $0 >= numberOfData }),
+                  !elementInserted.map({ $0.element }).contains(where: { $0 >= numberOfData }),
+                  !elementUpdated.map({ $0.element }).contains(where: { $0 >= numberOfData }),
+                  elementMoved.count == 0 else {
+                // too complicated to merge
+                return self
+            }
+
+            // Try to reduce actions: if an item needs to be updated there is no need to remove or insert that same item before.
+            elementUpdated.map({ $0.element }).forEach { elementToUpdate in
+                elementDeleted.removeAll(where: { $0.element == elementToUpdate })
+                elementInserted.removeAll(where: { $0.element == elementToUpdate })
+            }
+
+            // merge all elements in one item
+            lastItem.removeElements()
+            lastItem.updateElements(deleted: elementDeleted, inserted: elementInserted, updated: elementUpdated)
+
+            stagedChangeset.removeAll()
+            stagedChangeset.append(lastItem)
+            return stagedChangeset
+        }
+
+        return self
+    }
+}
+
+
+private extension Changeset {
+    mutating func removeElements() {
+        self.elementDeleted.removeAll()
+        self.elementInserted.removeAll()
+        self.elementUpdated.removeAll()
+        self.elementMoved.removeAll()
+    }
+
+    mutating func updateElements(deleted: [ElementPath], inserted: [ElementPath], updated: [ElementPath]) {
+        self.elementDeleted.append(contentsOf: deleted)
+        self.elementInserted.append(contentsOf: inserted)
+        self.elementUpdated.append(contentsOf: updated)
+    }
 }

--- a/Example/ChatLayout/Chat/View/ChatViewController.swift
+++ b/Example/ChatLayout/Chat/View/ChatViewController.swift
@@ -440,7 +440,7 @@ extension ChatViewController: ChatControllerDelegate {
         func process() {
             // If there is a big amount of changes, it is better to move that calculation out of the main thread.
             // Here is on the main thread for the simplicity.
-            let changeSet = StagedChangeset(source: dataSource.sections, target: sections).flattenIfPossible()
+            let changeSet = StagedChangeset(source: dataSource.sections, target: sections).flattenIfPossible().mergeChangesIfPossible()
 
             // In IOS 15 Apple as usual broke something in the UICollectionViewLayout and if simultaneous updates happen when the previous animation is not finished,
             // it doesnt caclulate content offset correctly. So we are blocking processing changes whilest the previoues batch update is in progress.


### PR DESCRIPTION
On the last release of the Chatlayout this issues was address but not really fixed.
In-fact in the example all actions are added one after the other. The way we use the library involves several changes at the same time. 

**Step to reproduce:**
Have two different actions in the same operation like: remove a message and add a new one.
To simulate that I have update the `sendMessage` function in `DefaultChatController` in line 63 by adding the following code:
`if !messages.isEmpty { messages.removeLast() }`

So now when you send a message it will delete the last message in the conversation at same time.
The `StagedChangeset` is a collection that now have two operations which implique two `performBatchUpdates`
![Sep-30-2021 14-22-31](https://user-images.githubusercontent.com/90382882/135455833-a2f61697-1c0f-48be-bd80-3e4d21bf97b4.gif)


**Changes suggestion**
This pull request try to fix the problem by coupling two solutions two solutions:

1 - Execute `performBatchUpdates` in series
2 - Try to merge the changes when it's possible in order to have only one `performBatchUpdates` to execute for several actions.

Remarque:
If we only do point 1, it appears that the animations can be jerky beceause there are all executed one after the other.

