### PR TITLE
Modify cell item spacing and section spacing to be changed using Delegate

### DIFF
--- a/ChatLayout/Classes/Core/ChatLayoutDelegate.swift
+++ b/ChatLayout/Classes/Core/ChatLayoutDelegate.swift
@@ -102,7 +102,19 @@ public protocol ChatLayoutDelegate: AnyObject {
                                              of kind: ItemKind,
                                              at indexPath: IndexPath,
                                              modifying originalAttributes: ChatLayoutAttributes)
-
+  
+    ///   Returns the interval between items.
+    ///
+    /// - Parameters:
+    ///   - section: Indicates the index of sections between items to return.
+    func collectionView(interItemSpacing section: Int) -> CGFloat?
+  
+    ///   Returns the interval between sections.
+    ///
+    /// - Parameters:
+    ///   - section: Indicates the index of sections to return.
+    func collectionView(interSectionSpacing section: Int) -> CGFloat?
+  
 }
 
 /// Default extension.
@@ -149,6 +161,16 @@ public extension ChatLayoutDelegate {
                                              at indexPath: IndexPath,
                                              modifying originalAttributes: ChatLayoutAttributes) {
         originalAttributes.alpha = 0
+    }
+  
+    /// Default implementation uses 'settings.interItemSpacing'.
+    func collectionView(interItemSpacing section: Int) -> CGFloat? {
+        return nil
+    }
+
+    /// Default implementation uses 'settings.interSectionSpacing'.
+    func collectionView(interSectionSpacing section: Int) -> CGFloat? {
+        return nil
     }
 
 }

--- a/ChatLayout/Classes/Core/Model/LayoutModel.swift
+++ b/ChatLayout/Classes/Core/Model/LayoutModel.swift
@@ -46,7 +46,8 @@ final class LayoutModel<Layout: ChatLayoutRepresentation> {
             for sectionIndex in 0..<directlyMutableSections.count {
                 sectionIndexByIdentifierCache[directlyMutableSections[sectionIndex].id] = sectionIndex
                 directlyMutableSections[sectionIndex].offsetY = offsetY
-                offsetY += directlyMutableSections[sectionIndex].height + collectionLayout.settings.interSectionSpacing
+                let spacing = (collectionLayout as? CollectionViewChatLayout)?.delegate?.collectionView(interSectionSpacing: sectionIndex) ?? collectionLayout.settings.interSectionSpacing
+                offsetY += directlyMutableSections[sectionIndex].height + spacing
                 if let header = directlyMutableSections[sectionIndex].header {
                     itemPathByIdentifierCache[ItemUUIDKey(kind: .header, id: header.id)] = ItemPath(item: 0, section: sectionIndex)
                 }

--- a/ChatLayout/Classes/Core/Model/SectionModel.swift
+++ b/ChatLayout/Classes/Core/Model/SectionModel.swift
@@ -73,7 +73,8 @@ struct SectionModel<Layout: ChatLayoutRepresentation> {
         items.withUnsafeMutableBufferPointer { directlyMutableItems in
             for rowIndex in 0..<directlyMutableItems.count {
                 directlyMutableItems[rowIndex].offsetY = offsetY
-                offsetY += directlyMutableItems[rowIndex].size.height + collectionLayout.settings.interItemSpacing
+                let spacing = (collectionLayout as? CollectionViewChatLayout)?.delegate?.collectionView(interItemSpacing: rowIndex) ?? collectionLayout.settings.interItemSpacing
+                offsetY += directlyMutableItems[rowIndex].size.height + spacing
             }
         }
 

--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -854,7 +854,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
 
         let visibleBounds = visibleBounds ?? layoutRepresentation.visibleBounds
         let minY = (visibleBounds.lowerPoint.y + batchUpdateCompensatingOffset + proposedCompensatingOffset).rounded()
-        let interItemSpacing = layoutRepresentation.settings.interItemSpacing
+        let interItemSpacing = (layoutRepresentation as? CollectionViewChatLayout)?.delegate?.collectionView(interItemSpacing: itemPath.item) ?? layoutRepresentation.settings.interItemSpacing
 
         switch action {
         case .insert:
@@ -895,7 +895,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
 
         let visibleBounds = visibleBounds ?? layoutRepresentation.visibleBounds
         let minY = (visibleBounds.lowerPoint.y + batchUpdateCompensatingOffset + proposedCompensatingOffset).rounded()
-        let interSectionSpacing = layoutRepresentation.settings.interSectionSpacing
+        let interSectionSpacing = (layoutRepresentation as? CollectionViewChatLayout)?.delegate?.collectionView(interSectionSpacing: sectionIndex) ?? layoutRepresentation.settings.interSectionSpacing
 
         switch action {
         case .insert:


### PR DESCRIPTION
Hello!
Thankfully, I am using ChatLayout well.🙇🏻‍♂️

During development, I received a requirement that the spacing of section and cell items should be different depending on the type.
Maybe I didn't find it, but as I checked, I had no choice but to specify the section and cell item spacing only with a specific value.

So, I made it possible to dynamically receive the spacing of items and the spacing between sections according to the section using the delegate pattern.

There must be a lot of room for improvement, but could you please review it?