### PR TITLE
 Implicit use of 'self' in closure

### DIFF
--- a/ChatLayout.podspec
+++ b/ChatLayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ChatLayout'
-  s.version          = '1.3.0'
+  s.version          = '1.3.1'
   s.summary          = 'Chat UI Library. It uses custom UICollectionViewLayout to provide you full control over the presentation.'
   s.swift_version    = '5.8'
 

--- a/ChatLayout/Classes/Extras/SwappingContainerView.swift
+++ b/ChatLayout/Classes/Extras/SwappingContainerView.swift
@@ -284,7 +284,7 @@ public final class SwappingContainerView<CustomView: UIView, AccessoryView: UIVi
                 guard let self else {
                     return
                 }
-                setNeedsUpdateConstraints()
+                self.setNeedsUpdateConstraints()
             }
         }
 
@@ -293,7 +293,7 @@ public final class SwappingContainerView<CustomView: UIView, AccessoryView: UIVi
                 guard let self else {
                     return
                 }
-                setNeedsUpdateConstraints()
+                self.setNeedsUpdateConstraints()
             }
 
         }


### PR DESCRIPTION
fix SwappingContainerView.swift:296:17 Implicit use of 'self' in closure; use 'self.' to make capture semantics explicit