### PR TITLE
Refactor deprecated unarchiveTopLevelObjectWithData

### DIFF
--- a/Example/ChatLayout/Chat/Model/Caching/Metadata/MetaDataCache.swift
+++ b/Example/ChatLayout/Chat/Model/Caching/Metadata/MetaDataCache.swift
@@ -50,9 +50,7 @@ final class MetaDataCache<Cache: AsyncKeyValueCaching>: AsyncKeyValueCaching whe
     }
 
     func store(entity: LPLinkMetadata, for key: URL) throws {
-        // swiftlint:disable force_try
-        let codedData = try! NSKeyedArchiver.archivedData(withRootObject: entity, requiringSecureCoding: true)
-        // swiftlint:enable force_try
+        let codedData = try NSKeyedArchiver.archivedData(withRootObject: entity, requiringSecureCoding: true)
         try cache.store(entity: codedData, for: key)
     }
 }

--- a/Example/ChatLayout/Chat/Model/Caching/Metadata/MetaDataCache.swift
+++ b/Example/ChatLayout/Chat/Model/Caching/Metadata/MetaDataCache.swift
@@ -28,9 +28,9 @@ final class MetaDataCache<Cache: AsyncKeyValueCaching>: AsyncKeyValueCaching whe
 
     func getEntity(for url: URL) throws -> LPLinkMetadata {
         let data = try cache.getEntity(for: url)
-        // swiftlint:disable force_try force_cast
-        let entity = try! NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(data) as! LPLinkMetadata
-        // swiftlint:enable force_try force_cast
+        guard let entity = try NSKeyedUnarchiver.unarchivedObject(ofClass: LPLinkMetadata.self, from: data) else {
+            throw CacheError.invalidData
+        }
         return entity
     }
 


### PR DESCRIPTION
Replace unarchiveTopLevelObjectWithData with unarchivedObject
https://developer.apple.com/documentation/foundation/nskeyedunarchiver/2919664-unarchivetoplevelobjectwithdata

Remove unnecessary force try and Swiftlint disable rules