### PR TITLE
 Implement pinned (sticky) header and footer

### DIFF
--- a/ChatLayout/Classes/Core/ChatLayoutDelegate.swift
+++ b/ChatLayout/Classes/Core/ChatLayoutDelegate.swift
@@ -39,6 +39,12 @@ public protocol ChatLayoutDelegate: AnyObject {
     /// - Returns: `Bool`.
     func shouldPresentFooter(_ chatLayout: CollectionViewChatLayout,
                              at sectionIndex: Int) -> Bool
+    
+    func shouldPinHeaderToVisibleBounds(_ chatLayout: CollectionViewChatLayout,
+                                        at sectionIndex: Int) -> Bool
+    
+    func shouldPinFooterToVisibleBounds(_ chatLayout: CollectionViewChatLayout,
+                                        at sectionIndex: Int) -> Bool
 
     /// `CollectionViewChatLayout` will call this method to ask what size the item should have.
     ///
@@ -131,6 +137,18 @@ public extension ChatLayoutDelegate {
     /// Default implementation returns: `false`.
     func shouldPresentFooter(_ chatLayout: CollectionViewChatLayout,
                              at sectionIndex: Int) -> Bool {
+        false
+    }
+    
+    /// Default implementation returns: `false`.
+    func shouldPinHeaderToVisibleBounds(_ chatLayout: CollectionViewChatLayout,
+                                        at sectionIndex: Int) -> Bool {
+        false
+    }
+    
+    /// Default implementation returns: `false`.
+    func shouldPinFooterToVisibleBounds(_ chatLayout: CollectionViewChatLayout,
+                                        at sectionIndex: Int) -> Bool {
         false
     }
 

--- a/ChatLayout/Classes/Core/ChatLayoutDelegate.swift
+++ b/ChatLayout/Classes/Core/ChatLayoutDelegate.swift
@@ -40,9 +40,19 @@ public protocol ChatLayoutDelegate: AnyObject {
     func shouldPresentFooter(_ chatLayout: CollectionViewChatLayout,
                              at sectionIndex: Int) -> Bool
     
+    /// `CollectionViewChatLayout` will call this method to ask if it should pin (stick) the header to the visible bounds in the current layout.
+    /// - Parameters:
+    ///   - chatLayout: `CollectionViewChatLayout` reference.
+    ///   - sectionIndex: Index of the section.
+    /// - Returns: `Bool`.
     func shouldPinHeaderToVisibleBounds(_ chatLayout: CollectionViewChatLayout,
                                         at sectionIndex: Int) -> Bool
     
+    /// `CollectionViewChatLayout` will call this method to ask if it should pin (stick) the footer to the visible bounds in the current layout.
+    /// - Parameters:
+    ///   - chatLayout: `CollectionViewChatLayout` reference.
+    ///   - sectionIndex: Index of the section.
+    /// - Returns: `Bool`.
     func shouldPinFooterToVisibleBounds(_ chatLayout: CollectionViewChatLayout,
                                         at sectionIndex: Int) -> Bool
 

--- a/ChatLayout/Classes/Core/ChatLayoutDelegate.swift
+++ b/ChatLayout/Classes/Core/ChatLayoutDelegate.swift
@@ -39,7 +39,7 @@ public protocol ChatLayoutDelegate: AnyObject {
     /// - Returns: `Bool`.
     func shouldPresentFooter(_ chatLayout: CollectionViewChatLayout,
                              at sectionIndex: Int) -> Bool
-    
+
     /// `CollectionViewChatLayout` will call this method to ask if it should pin (stick) the header to the visible bounds in the current layout.
     /// - Parameters:
     ///   - chatLayout: `CollectionViewChatLayout` reference.
@@ -47,7 +47,7 @@ public protocol ChatLayoutDelegate: AnyObject {
     /// - Returns: `Bool`.
     func shouldPinHeaderToVisibleBounds(_ chatLayout: CollectionViewChatLayout,
                                         at sectionIndex: Int) -> Bool
-    
+
     /// `CollectionViewChatLayout` will call this method to ask if it should pin (stick) the footer to the visible bounds in the current layout.
     /// - Parameters:
     ///   - chatLayout: `CollectionViewChatLayout` reference.
@@ -149,13 +149,13 @@ public extension ChatLayoutDelegate {
                              at sectionIndex: Int) -> Bool {
         false
     }
-    
+
     /// Default implementation returns: `false`.
     func shouldPinHeaderToVisibleBounds(_ chatLayout: CollectionViewChatLayout,
                                         at sectionIndex: Int) -> Bool {
         false
     }
-    
+
     /// Default implementation returns: `false`.
     func shouldPinFooterToVisibleBounds(_ chatLayout: CollectionViewChatLayout,
                                         at sectionIndex: Int) -> Bool {

--- a/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
+++ b/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
@@ -624,7 +624,7 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
             cachedCollectionViewInset != .some(adjustedContentInset) ||
             invalidationActions.contains(.shouldInvalidateOnBoundsChange)
             || (isUserInitiatedScrolling && state == .beforeUpdate)
-        
+
         invalidationActions.remove(.shouldInvalidateOnBoundsChange)
         return shouldInvalidateLayout || hasPinnedHeaderOrFooter
     }

--- a/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
+++ b/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
@@ -216,6 +216,8 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
     private var reconfigureItemsIndexPaths: [IndexPath] = []
 
     private var _supportSelfSizingInvalidation: Bool = false
+  
+    private var hasPinnedHeaderOrFooter: Bool = false
 
     // MARK: IOS 15.1 fix flags
 
@@ -619,7 +621,7 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
             || (isUserInitiatedScrolling && state == .beforeUpdate)
 
         invalidationActions.remove(.shouldInvalidateOnBoundsChange)
-        return shouldInvalidateLayout
+        return shouldInvalidateLayout || hasPinnedHeaderOrFooter
     }
 
     /// Retrieves a context object that defines the portions of the layout that should change when a bounds change occurs.

--- a/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
+++ b/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
@@ -217,7 +217,7 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
 
     private var _supportSelfSizingInvalidation: Bool = false
   
-    private var hasPinnedHeaderOrFooter: Bool = false
+    var hasPinnedHeaderOrFooter: Bool = false
 
     // MARK: IOS 15.1 fix flags
 
@@ -1056,15 +1056,11 @@ extension CollectionViewChatLayout: ChatLayoutRepresentation {
     }
     
     func shouldPinHeaderToVisibleBounds(at sectionIndex: Int) -> Bool {
-        let shouldPinHeaderToVisibleBounds = delegate?.shouldPinHeaderToVisibleBounds(self, at: sectionIndex) ?? false
-        hasPinnedHeaderOrFooter = hasPinnedHeaderOrFooter || shouldPinHeaderToVisibleBounds
-        return shouldPinHeaderToVisibleBounds
+        delegate?.shouldPinHeaderToVisibleBounds(self, at: sectionIndex) ?? false
     }
     
     func shouldPinFooterToVisibleBounds(at sectionIndex: Int) -> Bool {
-        let shouldPinFooterToVisibleBounds = delegate?.shouldPinFooterToVisibleBounds(self, at: sectionIndex) ?? false
-        hasPinnedHeaderOrFooter = hasPinnedHeaderOrFooter || shouldPinFooterToVisibleBounds
-        return shouldPinFooterToVisibleBounds
+        delegate?.shouldPinFooterToVisibleBounds(self, at: sectionIndex) ?? false
     }
 
     func interSectionSpacing(at sectionIndex: Int) -> CGFloat {

--- a/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
+++ b/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
@@ -1048,6 +1048,14 @@ extension CollectionViewChatLayout: ChatLayoutRepresentation {
     func shouldPresentFooter(at sectionIndex: Int) -> Bool {
         delegate?.shouldPresentFooter(self, at: sectionIndex) ?? false
     }
+    
+    func shouldPinHeaderToVisibleBounds(at sectionIndex: Int) -> Bool {
+        delegate?.shouldPinHeaderToVisibleBounds(self, at: sectionIndex) ?? false
+    }
+    
+    func shouldPinFooterToVisibleBounds(at sectionIndex: Int) -> Bool {
+        delegate?.shouldPinFooterToVisibleBounds(self, at: sectionIndex) ?? false
+    }
 
     func interSectionSpacing(at sectionIndex: Int) -> CGFloat {
         let interItemSpacing: CGFloat

--- a/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
+++ b/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
@@ -216,7 +216,7 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
     private var reconfigureItemsIndexPaths: [IndexPath] = []
 
     private var _supportSelfSizingInvalidation: Bool = false
-  
+
     var hasPinnedHeaderOrFooter: Bool = false
 
     // MARK: IOS 15.1 fix flags
@@ -346,9 +346,8 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
             resetAttributesForPendingAnimations()
             resetInvalidatedAttributes()
         }
-        
-        if prepareActions.contains(.updateLayoutMetrics) || prepareActions.contains(.recreateSectionModels)
-        {
+
+        if prepareActions.contains(.updateLayoutMetrics) || prepareActions.contains(.recreateSectionModels) {
             hasPinnedHeaderOrFooter = false
         }
 
@@ -625,7 +624,7 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
             cachedCollectionViewInset != .some(adjustedContentInset) ||
             invalidationActions.contains(.shouldInvalidateOnBoundsChange)
             || (isUserInitiatedScrolling && state == .beforeUpdate)
-
+        
         invalidationActions.remove(.shouldInvalidateOnBoundsChange)
         return shouldInvalidateLayout || hasPinnedHeaderOrFooter
     }

--- a/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
+++ b/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
@@ -346,6 +346,11 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
             resetAttributesForPendingAnimations()
             resetInvalidatedAttributes()
         }
+        
+        if prepareActions.contains(.updateLayoutMetrics) || prepareActions.contains(.recreateSectionModels)
+        {
+            hasPinnedHeaderOrFooter = false
+        }
 
         if prepareActions.contains(.recreateSectionModels) {
             var sections: ContiguousArray<SectionModel<CollectionViewChatLayout>> = []
@@ -379,6 +384,8 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
                                            footer: footer,
                                            items: items,
                                            collectionLayout: self)
+                section.set(isPinHeaderToVisibleBounds: shouldPinHeaderToVisibleBounds(at: sectionIndex))
+                section.set(isPinFooterToVisibleBounds: shouldPinFooterToVisibleBounds(at: sectionIndex))
                 section.assembleLayout()
                 sections.append(section)
             }
@@ -470,7 +477,6 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
             return nil
         }
         let attributes = controller.itemAttributes(for: indexPath.itemPath, kind: .cell, at: state)
-
         return attributes
     }
 
@@ -1050,11 +1056,15 @@ extension CollectionViewChatLayout: ChatLayoutRepresentation {
     }
     
     func shouldPinHeaderToVisibleBounds(at sectionIndex: Int) -> Bool {
-        delegate?.shouldPinHeaderToVisibleBounds(self, at: sectionIndex) ?? false
+        let shouldPinHeaderToVisibleBounds = delegate?.shouldPinHeaderToVisibleBounds(self, at: sectionIndex) ?? false
+        hasPinnedHeaderOrFooter = hasPinnedHeaderOrFooter || shouldPinHeaderToVisibleBounds
+        return shouldPinHeaderToVisibleBounds
     }
     
     func shouldPinFooterToVisibleBounds(at sectionIndex: Int) -> Bool {
-        delegate?.shouldPinFooterToVisibleBounds(self, at: sectionIndex) ?? false
+        let shouldPinFooterToVisibleBounds = delegate?.shouldPinFooterToVisibleBounds(self, at: sectionIndex) ?? false
+        hasPinnedHeaderOrFooter = hasPinnedHeaderOrFooter || shouldPinFooterToVisibleBounds
+        return shouldPinFooterToVisibleBounds
     }
 
     func interSectionSpacing(at sectionIndex: Int) -> CGFloat {

--- a/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
+++ b/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
@@ -383,8 +383,8 @@ open class CollectionViewChatLayout: UICollectionViewLayout {
                                            footer: footer,
                                            items: items,
                                            collectionLayout: self)
-                section.set(isPinHeaderToVisibleBounds: shouldPinHeaderToVisibleBounds(at: sectionIndex))
-                section.set(isPinFooterToVisibleBounds: shouldPinFooterToVisibleBounds(at: sectionIndex))
+                section.set(shouldPinHeaderToVisibleBounds: shouldPinHeaderToVisibleBounds(at: sectionIndex))
+                section.set(shouldPinFooterToVisibleBounds: shouldPinFooterToVisibleBounds(at: sectionIndex))
                 section.assembleLayout()
                 sections.append(section)
             }

--- a/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
+++ b/ChatLayout/Classes/Core/CollectionViewChatLayout.swift
@@ -1054,11 +1054,11 @@ extension CollectionViewChatLayout: ChatLayoutRepresentation {
     func shouldPresentFooter(at sectionIndex: Int) -> Bool {
         delegate?.shouldPresentFooter(self, at: sectionIndex) ?? false
     }
-    
+
     func shouldPinHeaderToVisibleBounds(at sectionIndex: Int) -> Bool {
         delegate?.shouldPinHeaderToVisibleBounds(self, at: sectionIndex) ?? false
     }
-    
+
     func shouldPinFooterToVisibleBounds(at sectionIndex: Int) -> Bool {
         delegate?.shouldPinFooterToVisibleBounds(self, at: sectionIndex) ?? false
     }

--- a/ChatLayout/Classes/Core/Model/SectionModel.swift
+++ b/ChatLayout/Classes/Core/Model/SectionModel.swift
@@ -19,11 +19,11 @@ struct SectionModel<Layout: ChatLayoutRepresentation> {
     let interSectionSpacing: CGFloat
 
     private(set) var header: ItemModel?
-    
+
     private(set) var footer: ItemModel?
-    
+
     private(set) var isPinHeaderToVisibleBounds: Bool = false
-    
+
     private(set) var isPinFooterToVisibleBounds: Bool = false
 
     private(set) var items: ContiguousArray<ItemModel>

--- a/ChatLayout/Classes/Core/Model/SectionModel.swift
+++ b/ChatLayout/Classes/Core/Model/SectionModel.swift
@@ -144,7 +144,7 @@ struct SectionModel<Layout: ChatLayoutRepresentation> {
     mutating func set(items: ContiguousArray<ItemModel>) {
         self.items = items
     }
-
+    
     mutating func set(footer: ItemModel?) {
         self.footer = footer
     }

--- a/ChatLayout/Classes/Core/Model/SectionModel.swift
+++ b/ChatLayout/Classes/Core/Model/SectionModel.swift
@@ -22,9 +22,9 @@ struct SectionModel<Layout: ChatLayoutRepresentation> {
 
     private(set) var footer: ItemModel?
 
-    private(set) var isPinHeaderToVisibleBounds: Bool = false
+    private(set) var shouldPinHeaderToVisibleBounds: Bool = false
 
-    private(set) var isPinFooterToVisibleBounds: Bool = false
+    private(set) var shouldPinFooterToVisibleBounds: Bool = false
 
     private(set) var items: ContiguousArray<ItemModel>
 
@@ -149,12 +149,12 @@ struct SectionModel<Layout: ChatLayoutRepresentation> {
         self.footer = footer
     }
 
-    mutating func set(isPinHeaderToVisibleBounds: Bool) {
-        self.isPinHeaderToVisibleBounds = isPinHeaderToVisibleBounds
+    mutating func set(shouldPinHeaderToVisibleBounds: Bool) {
+        self.shouldPinHeaderToVisibleBounds = shouldPinHeaderToVisibleBounds
     }
 
-    mutating func set(isPinFooterToVisibleBounds: Bool) {
-        self.isPinFooterToVisibleBounds = isPinFooterToVisibleBounds
+    mutating func set(shouldPinFooterToVisibleBounds: Bool) {
+        self.shouldPinFooterToVisibleBounds = shouldPinFooterToVisibleBounds
     }
 
     private mutating func offsetEverything(below index: Int, by heightDiff: CGFloat) {

--- a/ChatLayout/Classes/Core/Model/SectionModel.swift
+++ b/ChatLayout/Classes/Core/Model/SectionModel.swift
@@ -144,15 +144,15 @@ struct SectionModel<Layout: ChatLayoutRepresentation> {
     mutating func set(items: ContiguousArray<ItemModel>) {
         self.items = items
     }
-    
+
     mutating func set(footer: ItemModel?) {
         self.footer = footer
     }
-    
+
     mutating func set(isPinHeaderToVisibleBounds: Bool) {
         self.isPinHeaderToVisibleBounds = isPinHeaderToVisibleBounds
     }
-    
+
     mutating func set(isPinFooterToVisibleBounds: Bool) {
         self.isPinFooterToVisibleBounds = isPinFooterToVisibleBounds
     }

--- a/ChatLayout/Classes/Core/Model/SectionModel.swift
+++ b/ChatLayout/Classes/Core/Model/SectionModel.swift
@@ -19,8 +19,12 @@ struct SectionModel<Layout: ChatLayoutRepresentation> {
     let interSectionSpacing: CGFloat
 
     private(set) var header: ItemModel?
-
+    
     private(set) var footer: ItemModel?
+    
+    private(set) var isPinHeaderToVisibleBounds: Bool = false
+    
+    private(set) var isPinFooterToVisibleBounds: Bool = false
 
     private(set) var items: ContiguousArray<ItemModel>
 
@@ -143,6 +147,14 @@ struct SectionModel<Layout: ChatLayoutRepresentation> {
 
     mutating func set(footer: ItemModel?) {
         self.footer = footer
+    }
+    
+    mutating func set(isPinHeaderToVisibleBounds: Bool) {
+        self.isPinHeaderToVisibleBounds = isPinHeaderToVisibleBounds
+    }
+    
+    mutating func set(isPinFooterToVisibleBounds: Bool) {
+        self.isPinFooterToVisibleBounds = isPinFooterToVisibleBounds
     }
 
     private mutating func offsetEverything(below index: Int, by heightDiff: CGFloat) {

--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -381,14 +381,14 @@ final class StateController<Layout: ChatLayoutRepresentation> {
 
         if kind == .header && section.isPinHeaderToVisibleBounds == true {
             layoutRepresentation.hasPinnedHeaderOrFooter = true
-            let dy = max(min(visibleBounds.minY - section.offsetY, section.height - (section.footer?.size.height ?? 0) - item.size.height), 0)
-            itemFrame.offsettingBy(dx: 0, dy: dy)
+            let offsetY = max(min(visibleBounds.minY - section.offsetY, section.height - (section.footer?.size.height ?? 0) - item.size.height), 0)
+            itemFrame.offsettingBy(dx: 0, dy: offsetY)
         }
-        
+
         if kind == .footer && section.isPinFooterToVisibleBounds == true {
             layoutRepresentation.hasPinnedHeaderOrFooter = true
-            let dy = max(min(0, visibleBounds.maxY - item.size.height - itemFrame.minY), section.offsetY + (section.header?.size.height ?? 0) - itemFrame.minY)
-            itemFrame.offsettingBy(dx: 0, dy: dy)
+            let offsetY = max(min(0, visibleBounds.maxY - item.size.height - itemFrame.minY), section.offsetY + (section.header?.size.height ?? 0) - itemFrame.minY)
+            itemFrame.offsettingBy(dx: 0, dy: offsetY)
         }
 
         if isFinal {

--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -745,11 +745,13 @@ final class StateController<Layout: ChatLayoutRepresentation> {
                 } else {
                     footer = nil
                 }
-                let section = SectionModel(interSectionSpacing: layoutRepresentation.interSectionSpacing(at: sectionIndex),
+                var section = SectionModel(interSectionSpacing: layoutRepresentation.interSectionSpacing(at: sectionIndex),
                                            header: header,
                                            footer: footer,
                                            items: ContiguousArray(items),
                                            collectionLayout: layoutRepresentation)
+                section.set(isPinHeaderToVisibleBounds: layoutRepresentation.shouldPinHeaderToVisibleBounds(at: sectionIndex))
+                section.set(isPinFooterToVisibleBounds: layoutRepresentation.shouldPinFooterToVisibleBounds(at: sectionIndex))
                 insertedSection = section
                 afterUpdateModel.insertSection(section, at: sectionIndex)
             }

--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -185,8 +185,10 @@ final class StateController<Layout: ChatLayoutRepresentation> {
             return .orderedSame
         }
         
+        // When using pinned (sticky) headers and footers, frames may not be aligned correctly.
+        // As a result, binary search not work properly, so iterate through the array instead.
         let hasPinnedHeaderOrFooter = layoutRepresentation.hasPinnedHeaderOrFooter
-        
+
         if !ignoreCache,
            let cachedAttributesState,
            cachedAttributesState.rect.contains(rect) {
@@ -376,7 +378,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
         }
 
         itemFrame.offsettingBy(dx: dx, dy: section.offsetY)
-        
+
         if kind == .header && section.isPinHeaderToVisibleBounds == true {
             layoutRepresentation.hasPinnedHeaderOrFooter = true
             let offsetY = max(

--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -1091,8 +1091,10 @@ final class StateController<Layout: ChatLayoutRepresentation> {
                     }
                 }
 
+                // When using pinned (sticky) footers, even if the cell does not intersect with the frame, the footer can intersect.
+                // Therefore, add the footer without considering the traverseState.
                 if let footerFrame = itemFrame(for: sectionPath, kind: .footer, at: state, isFinal: true, additionalAttributes: additionalAttributes),
-                   check(rect: footerFrame) {
+                   check(rect: footerFrame) || (section.isPinFooterToVisibleBounds && section.frame.intersects(visibleRect)) {
                     allRects.append((frame: footerFrame, indexPath: sectionPath, kind: .footer))
                 }
             }

--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -379,13 +379,13 @@ final class StateController<Layout: ChatLayoutRepresentation> {
 
         itemFrame.offsettingBy(dx: dx, dy: section.offsetY)
 
-        if kind == .header && section.isPinHeaderToVisibleBounds == true {
+        if kind == .header && section.shouldPinHeaderToVisibleBounds == true {
             layoutRepresentation.hasPinnedHeaderOrFooter = true
             let offsetY = max(min(visibleBounds.minY - section.offsetY, section.height - (section.footer?.size.height ?? 0) - item.size.height), 0)
             itemFrame.offsettingBy(dx: 0, dy: offsetY)
         }
 
-        if kind == .footer && section.isPinFooterToVisibleBounds == true {
+        if kind == .footer && section.shouldPinFooterToVisibleBounds == true {
             layoutRepresentation.hasPinnedHeaderOrFooter = true
             let offsetY = max(min(0, visibleBounds.maxY - item.size.height - itemFrame.minY), section.offsetY + (section.header?.size.height ?? 0) - itemFrame.minY)
             itemFrame.offsettingBy(dx: 0, dy: offsetY)
@@ -746,8 +746,8 @@ final class StateController<Layout: ChatLayoutRepresentation> {
                                            footer: footer,
                                            items: ContiguousArray(items),
                                            collectionLayout: layoutRepresentation)
-                section.set(isPinHeaderToVisibleBounds: layoutRepresentation.shouldPinHeaderToVisibleBounds(at: sectionIndex))
-                section.set(isPinFooterToVisibleBounds: layoutRepresentation.shouldPinFooterToVisibleBounds(at: sectionIndex))
+                section.set(shouldPinHeaderToVisibleBounds: layoutRepresentation.shouldPinHeaderToVisibleBounds(at: sectionIndex))
+                section.set(shouldPinFooterToVisibleBounds: layoutRepresentation.shouldPinFooterToVisibleBounds(at: sectionIndex))
                 insertedSection = section
                 afterUpdateModel.insertSection(section, at: sectionIndex)
             }
@@ -1090,7 +1090,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
                 // When using pinned (sticky) footers, even if the cell does not intersect with the frame, the footer can intersect.
                 // Therefore, add the footer without considering the traverseState.
                 if let footerFrame = itemFrame(for: sectionPath, kind: .footer, at: state, isFinal: true, additionalAttributes: additionalAttributes),
-                   check(rect: footerFrame) || (section.isPinFooterToVisibleBounds && section.frame.intersects(visibleRect)) {
+                   check(rect: footerFrame) || (section.shouldPinFooterToVisibleBounds && section.frame.intersects(visibleRect)) {
                     allRects.append((frame: footerFrame, indexPath: sectionPath, kind: .footer))
                 }
             }

--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -381,18 +381,14 @@ final class StateController<Layout: ChatLayoutRepresentation> {
 
         if kind == .header && section.isPinHeaderToVisibleBounds == true {
             layoutRepresentation.hasPinnedHeaderOrFooter = true
-            let offsetY = max(
-                min(visibleBounds.minY - section.offsetY, section.height - additionalInsets.bottom - (section.footer?.size.height ?? 0) - item.size.height
-                   ), item.offsetY)
-            itemFrame.offsettingBy(dx: 0, dy: offsetY)
+            let dy = max(min(visibleBounds.minY - section.offsetY, section.height - (section.footer?.size.height ?? 0) - item.size.height), 0)
+            itemFrame.offsettingBy(dx: 0, dy: dy)
         }
-
+        
         if kind == .footer && section.isPinFooterToVisibleBounds == true {
             layoutRepresentation.hasPinnedHeaderOrFooter = true
-            let offsetY = max(min(
-                0, visibleBounds.maxY + layoutRepresentation.adjustedContentInset.bottom - item.size.height - itemFrame.minY
-            ), section.offsetY + (section.header?.size.height ?? 0) - itemFrame.minY)
-            itemFrame.offsettingBy(dx: 0, dy: offsetY)
+            let dy = max(min(0, visibleBounds.maxY - item.size.height - itemFrame.minY), section.offsetY + (section.header?.size.height ?? 0) - itemFrame.minY)
+            itemFrame.offsettingBy(dx: 0, dy: dy)
         }
 
         if isFinal {

--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -30,7 +30,7 @@ protocol ChatLayoutRepresentation: AnyObject {
     var keepContentAtBottomOfVisibleArea: Bool { get }
 
     var processOnlyVisibleItemsOnAnimatedBatchUpdates: Bool { get }
-    
+
     var hasPinnedHeaderOrFooter: Bool { get set }
 
     func numberOfItems(in section: Int) -> Int
@@ -40,11 +40,11 @@ protocol ChatLayoutRepresentation: AnyObject {
     func shouldPresentHeader(at sectionIndex: Int) -> Bool
 
     func shouldPresentFooter(at sectionIndex: Int) -> Bool
-    
+
     func shouldPinHeaderToVisibleBounds(at sectionIndex: Int) -> Bool
-    
+
     func shouldPinFooterToVisibleBounds(at sectionIndex: Int) -> Bool
-    
+
     func interSectionSpacing(at sectionIndex: Int) -> CGFloat
 }
 
@@ -247,7 +247,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
         let attributes: ChatLayoutAttributes
         let itemIndexPath = itemPath.indexPath
         let layout = layout(at: state)
-        
+
         switch kind {
         case .header:
             guard itemPath.section < layout.sections.count,

--- a/ChatLayout/Classes/Core/Model/StateController.swift
+++ b/ChatLayout/Classes/Core/Model/StateController.swift
@@ -184,7 +184,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
             }
             return .orderedSame
         }
-        
+
         // When using pinned (sticky) headers and footers, frames may not be aligned correctly.
         // As a result, binary search not work properly, so iterate through the array instead.
         let hasPinnedHeaderOrFooter = layoutRepresentation.hasPinnedHeaderOrFooter
@@ -207,7 +207,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
             if !ignoreCache {
                 cachedAttributesState = (rect: totalRect, attributes: attributes)
             }
-            
+
             let visibleAttributes: [ChatLayoutAttributes]
             if rect == totalRect {
                 visibleAttributes = attributes
@@ -386,7 +386,7 @@ final class StateController<Layout: ChatLayoutRepresentation> {
                    ), item.offsetY)
             itemFrame.offsettingBy(dx: 0, dy: offsetY)
         }
-        
+
         if kind == .footer && section.isPinFooterToVisibleBounds == true {
             layoutRepresentation.hasPinnedHeaderOrFooter = true
             let offsetY = max(min(
@@ -394,17 +394,17 @@ final class StateController<Layout: ChatLayoutRepresentation> {
             ), section.offsetY + (section.header?.size.height ?? 0) - itemFrame.minY)
             itemFrame.offsettingBy(dx: 0, dy: offsetY)
         }
-        
+
         if isFinal {
             offsetByCompensation(frame: &itemFrame, at: itemPath, for: state, backward: true)
         }
-        
+
         if layoutRepresentation.keepContentAtBottomOfVisibleArea == true,
            !(kind == .header && itemPath.section == 0),
            !isLayoutBiggerThanVisibleBounds(at: state, withFullCompensation: false, visibleBounds: visibleBounds) {
             itemFrame.offsettingBy(dx: 0, dy: visibleBounds.height.rounded() - contentSize(for: state).height.rounded())
         }
-        
+
         return itemFrame
     }
 

--- a/Example/ChatLayout/Chat/View/Data Source/DefaultChatCollectionDataSource.swift
+++ b/Example/ChatLayout/Chat/View/Data Source/DefaultChatCollectionDataSource.swift
@@ -317,6 +317,14 @@ extension DefaultChatCollectionDataSource: ChatLayoutDelegate {
     public func shouldPresentFooter(_ chatLayout: CollectionViewChatLayout, at sectionIndex: Int) -> Bool {
         true
     }
+    
+    public func shouldPinFooterToVisibleBounds(_ chatLayout: CollectionViewChatLayout, at sectionIndex: Int) -> Bool {
+        true
+    }
+    
+    public func shouldPinHeaderToVisibleBounds(_ chatLayout: CollectionViewChatLayout, at sectionIndex: Int) -> Bool {
+        true
+    }
 
     public func sizeForItem(_ chatLayout: CollectionViewChatLayout, of kind: ItemKind, at indexPath: IndexPath) -> ItemSize {
         switch kind {

--- a/Example/ChatLayout/Chat/View/Data Source/DefaultChatCollectionDataSource.swift
+++ b/Example/ChatLayout/Chat/View/Data Source/DefaultChatCollectionDataSource.swift
@@ -318,14 +318,6 @@ extension DefaultChatCollectionDataSource: ChatLayoutDelegate {
         true
     }
 
-    public func shouldPinFooterToVisibleBounds(_ chatLayout: CollectionViewChatLayout, at sectionIndex: Int) -> Bool {
-        false
-    }
-
-    public func shouldPinHeaderToVisibleBounds(_ chatLayout: CollectionViewChatLayout, at sectionIndex: Int) -> Bool {
-        true
-    }
-
     public func sizeForItem(_ chatLayout: CollectionViewChatLayout, of kind: ItemKind, at indexPath: IndexPath) -> ItemSize {
         switch kind {
         case .cell:

--- a/Example/ChatLayout/Chat/View/Data Source/DefaultChatCollectionDataSource.swift
+++ b/Example/ChatLayout/Chat/View/Data Source/DefaultChatCollectionDataSource.swift
@@ -317,11 +317,11 @@ extension DefaultChatCollectionDataSource: ChatLayoutDelegate {
     public func shouldPresentFooter(_ chatLayout: CollectionViewChatLayout, at sectionIndex: Int) -> Bool {
         true
     }
-    
+
     public func shouldPinFooterToVisibleBounds(_ chatLayout: CollectionViewChatLayout, at sectionIndex: Int) -> Bool {
-        true
+        false
     }
-    
+
     public func shouldPinHeaderToVisibleBounds(_ chatLayout: CollectionViewChatLayout, at sectionIndex: Int) -> Bool {
         true
     }

--- a/Example/Tests/MockCollectionLayout.swift
+++ b/Example/Tests/MockCollectionLayout.swift
@@ -18,8 +18,8 @@ class MockCollectionLayout: ChatLayoutRepresentation, ChatLayoutDelegate {
     var numberOfItemsInSection: [Int: Int] = [0: 100, 1: 100, 2: 100]
     var shouldPresentHeaderAtSection: [Int: Bool] = [0: true, 1: true, 2: true]
     var shouldPresentFooterAtSection: [Int: Bool] = [0: true, 1: true, 2: true]
-    var shouldPinHeaderToVisibleBoundsAtSection: [Int: Bool] = [0: true, 1: true, 2: true]
-    var shouldPinFooterToVisibleBoundsAtSection: [Int: Bool] = [0: true, 1: true, 2: true]
+    var shouldPinHeaderToVisibleBoundsAtSection: [Int: Bool] = [0: false, 1: false, 2: false]
+    var shouldPinFooterToVisibleBoundsAtSection: [Int: Bool] = [0: false, 1: false, 2: false]
 
     // swiftlint:disable weak_delegate
     lazy var delegate: ChatLayoutDelegate? = self
@@ -106,6 +106,8 @@ class MockCollectionLayout: ChatLayoutRepresentation, ChatLayoutDelegate {
             }
 
             var section = SectionModel(interSectionSpacing: interSectionSpacing(at: sectionIndex), header: header, footer: footer, items: items, collectionLayout: self)
+            section.set(isPinHeaderToVisibleBounds: shouldPinHeaderToVisibleBounds(at: sectionIndex))
+            section.set(isPinFooterToVisibleBounds: shouldPinFooterToVisibleBounds(at: sectionIndex))
             section.assembleLayout()
             sections.append(section)
         }

--- a/Example/Tests/MockCollectionLayout.swift
+++ b/Example/Tests/MockCollectionLayout.swift
@@ -47,11 +47,11 @@ class MockCollectionLayout: ChatLayoutRepresentation, ChatLayoutDelegate {
     let keepContentOffsetAtBottomOnBatchUpdates: Bool = true
 
     let keepContentAtBottomOfVisibleArea: Bool = false
-
+    
     let processOnlyVisibleItemsOnAnimatedBatchUpdates: Bool = true
     
     var hasPinnedHeaderOrFooter: Bool = false
-
+    
     func numberOfItems(in section: Int) -> Int {
         numberOfItemsInSection[section] ?? 0
     }

--- a/Example/Tests/MockCollectionLayout.swift
+++ b/Example/Tests/MockCollectionLayout.swift
@@ -47,11 +47,11 @@ class MockCollectionLayout: ChatLayoutRepresentation, ChatLayoutDelegate {
     let keepContentOffsetAtBottomOnBatchUpdates: Bool = true
 
     let keepContentAtBottomOfVisibleArea: Bool = false
-    
+
     let processOnlyVisibleItemsOnAnimatedBatchUpdates: Bool = true
-    
+
     var hasPinnedHeaderOrFooter: Bool = false
-    
+
     func numberOfItems(in section: Int) -> Int {
         numberOfItemsInSection[section] ?? 0
     }
@@ -67,15 +67,15 @@ class MockCollectionLayout: ChatLayoutRepresentation, ChatLayoutDelegate {
     func shouldPresentFooter(at sectionIndex: Int) -> Bool {
         shouldPresentFooterAtSection[sectionIndex] ?? true
     }
-    
+
     func shouldPinHeaderToVisibleBounds(at sectionIndex: Int) -> Bool {
         shouldPinHeaderToVisibleBoundsAtSection[sectionIndex] ?? true
     }
-    
+
     func shouldPinFooterToVisibleBounds(at sectionIndex: Int) -> Bool {
         shouldPinFooterToVisibleBoundsAtSection[sectionIndex] ?? true
     }
-    
+
     func alignment(for element: ItemKind, at itemPath: ItemPath) -> ChatItemAlignment {
         alignmentForItem(of: element, at: itemPath.indexPath)
     }

--- a/Example/Tests/MockCollectionLayout.swift
+++ b/Example/Tests/MockCollectionLayout.swift
@@ -106,8 +106,8 @@ class MockCollectionLayout: ChatLayoutRepresentation, ChatLayoutDelegate {
             }
 
             var section = SectionModel(interSectionSpacing: interSectionSpacing(at: sectionIndex), header: header, footer: footer, items: items, collectionLayout: self)
-            section.set(isPinHeaderToVisibleBounds: shouldPinHeaderToVisibleBounds(at: sectionIndex))
-            section.set(isPinFooterToVisibleBounds: shouldPinFooterToVisibleBounds(at: sectionIndex))
+            section.set(shouldPinHeaderToVisibleBounds: shouldPinHeaderToVisibleBounds(at: sectionIndex))
+            section.set(shouldPinFooterToVisibleBounds: shouldPinFooterToVisibleBounds(at: sectionIndex))
             section.assembleLayout()
             sections.append(section)
         }

--- a/Example/Tests/MockCollectionLayout.swift
+++ b/Example/Tests/MockCollectionLayout.swift
@@ -18,6 +18,8 @@ class MockCollectionLayout: ChatLayoutRepresentation, ChatLayoutDelegate {
     var numberOfItemsInSection: [Int: Int] = [0: 100, 1: 100, 2: 100]
     var shouldPresentHeaderAtSection: [Int: Bool] = [0: true, 1: true, 2: true]
     var shouldPresentFooterAtSection: [Int: Bool] = [0: true, 1: true, 2: true]
+    var shouldPinHeaderToVisibleBoundsAtSection: [Int: Bool] = [0: true, 1: true, 2: true]
+    var shouldPinFooterToVisibleBoundsAtSection: [Int: Bool] = [0: true, 1: true, 2: true]
 
     // swiftlint:disable weak_delegate
     lazy var delegate: ChatLayoutDelegate? = self
@@ -47,6 +49,8 @@ class MockCollectionLayout: ChatLayoutRepresentation, ChatLayoutDelegate {
     let keepContentAtBottomOfVisibleArea: Bool = false
 
     let processOnlyVisibleItemsOnAnimatedBatchUpdates: Bool = true
+    
+    var hasPinnedHeaderOrFooter: Bool = false
 
     func numberOfItems(in section: Int) -> Int {
         numberOfItemsInSection[section] ?? 0
@@ -63,7 +67,15 @@ class MockCollectionLayout: ChatLayoutRepresentation, ChatLayoutDelegate {
     func shouldPresentFooter(at sectionIndex: Int) -> Bool {
         shouldPresentFooterAtSection[sectionIndex] ?? true
     }
-
+    
+    func shouldPinHeaderToVisibleBounds(at sectionIndex: Int) -> Bool {
+        shouldPinHeaderToVisibleBoundsAtSection[sectionIndex] ?? true
+    }
+    
+    func shouldPinFooterToVisibleBounds(at sectionIndex: Int) -> Bool {
+        shouldPinFooterToVisibleBoundsAtSection[sectionIndex] ?? true
+    }
+    
     func alignment(for element: ItemKind, at itemPath: ItemPath) -> ChatItemAlignment {
         alignmentForItem(of: element, at: itemPath.indexPath)
     }

--- a/Example/Tests/PerformanceTests.swift
+++ b/Example/Tests/PerformanceTests.swift
@@ -83,6 +83,8 @@ final class PerformanceTests: XCTestCase {
         layout.numberOfItemsInSection[1] = 100000
         layout.shouldPresentHeaderAtSection = [0: false, 1: false]
         layout.shouldPresentFooterAtSection = [0: false, 1: false]
+        layout.shouldPinHeaderToVisibleBoundsAtSection = [2: true]
+        layout.shouldPinFooterToVisibleBoundsAtSection = [2: true]
         layout.settings.additionalInsets = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
         layout.settings.estimatedItemSize = CGSize(width: 300, height: 1)
         layout.settings.interItemSpacing = 0

--- a/Example/Tests/PerformanceTests.swift
+++ b/Example/Tests/PerformanceTests.swift
@@ -91,7 +91,7 @@ final class PerformanceTests: XCTestCase {
         layout.settings.interSectionSpacing = 0
         layout.controller.set(layout.getPreparedSections(), at: .beforeUpdate)
         layout.hasPinnedHeaderOrFooter = true
-        
+
         let rect = CGRect(origin: CGPoint(x: 0, y: 99999), size: CGSize(width: 300, height: 2))
         let attributes = layout.controller.layoutAttributesForElements(in: rect, state: .beforeUpdate, ignoreCache: true)
         XCTAssertEqual(attributes.count, 2)

--- a/Example/Tests/PerformanceTests.swift
+++ b/Example/Tests/PerformanceTests.swift
@@ -76,7 +76,7 @@ final class PerformanceTests: XCTestCase {
             }
         }
     }
-    
+
     func testPinnedLayoutAttributesForElementsPerformance() {
         let layout = MockCollectionLayout()
         layout.numberOfItemsInSection[0] = 100000

--- a/Example/Tests/PerformanceTests.swift
+++ b/Example/Tests/PerformanceTests.swift
@@ -76,6 +76,29 @@ final class PerformanceTests: XCTestCase {
             }
         }
     }
+    
+    func testPinnedLayoutAttributesForElementsPerformance() {
+        let layout = MockCollectionLayout()
+        layout.numberOfItemsInSection[0] = 100000
+        layout.numberOfItemsInSection[1] = 100000
+        layout.shouldPresentHeaderAtSection = [0: false, 1: false]
+        layout.shouldPresentFooterAtSection = [0: false, 1: false]
+        layout.settings.additionalInsets = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
+        layout.settings.estimatedItemSize = CGSize(width: 300, height: 1)
+        layout.settings.interItemSpacing = 0
+        layout.settings.interSectionSpacing = 0
+        layout.controller.set(layout.getPreparedSections(), at: .beforeUpdate)
+        layout.hasPinnedHeaderOrFooter = true
+        
+        let rect = CGRect(origin: CGPoint(x: 0, y: 99999), size: CGSize(width: 300, height: 2))
+        let attributes = layout.controller.layoutAttributesForElements(in: rect, state: .beforeUpdate, ignoreCache: true)
+        XCTAssertEqual(attributes.count, 2)
+        measure {
+            for _ in 0..<10 {
+                _ = layout.controller.layoutAttributesForElements(in: rect, state: .beforeUpdate, ignoreCache: true)
+            }
+        }
+    }
 
     func testInsertionPerformance() {
         let layout = MockCollectionLayout()

--- a/Example/Tests/StateControllerProcessUpdatesTests.swift
+++ b/Example/Tests/StateControllerProcessUpdatesTests.swift
@@ -374,4 +374,24 @@ class StateControllerProcessUpdatesTests: XCTestCase {
         XCTAssertEqual(layout.controller.numberOfItems(in: 0, at: .beforeUpdate), 3)
         XCTAssertEqual(layout.controller.numberOfItems(in: 0, at: .afterUpdate), 4)
     }
+    
+    func testPinnedHeader() {
+        let layout = MockCollectionLayout()
+        let scrollOffsetY = CGFloat(400)
+        layout.visibleBounds.origin.y = scrollOffsetY
+        layout.shouldPinHeaderToVisibleBoundsAtSection[0] = true
+        layout.controller.set(layout.getPreparedSections(), at: .beforeUpdate)
+
+        let item = layout.controller.itemAttributes(for: ItemPath(item: 0, section: 0), kind: .header, at: .beforeUpdate)
+        XCTAssertEqual(item?.frame.minY, scrollOffsetY)
+    }
+    
+    func testPinnedFooter() {
+        let layout = MockCollectionLayout()
+        layout.shouldPinFooterToVisibleBoundsAtSection[0] = true
+        layout.controller.set(layout.getPreparedSections(), at: .beforeUpdate)
+
+        let item = layout.controller.itemAttributes(for: ItemPath(item: 0, section: 0), kind: .footer, at: .beforeUpdate)!
+        XCTAssertEqual(item.frame.minY, layout.visibleBounds.height - item.frame.height)
+    }
 }

--- a/Example/Tests/StateControllerProcessUpdatesTests.swift
+++ b/Example/Tests/StateControllerProcessUpdatesTests.swift
@@ -385,7 +385,7 @@ class StateControllerProcessUpdatesTests: XCTestCase {
         let item = layout.controller.itemAttributes(for: ItemPath(item: 0, section: 0), kind: .header, at: .beforeUpdate)
         XCTAssertEqual(item?.frame.minY, scrollOffsetY)
     }
-    
+
     func testPinnedFooter() {
         let layout = MockCollectionLayout()
         layout.shouldPinFooterToVisibleBoundsAtSection[0] = true

--- a/Example/Tests/StateControllerProcessUpdatesTests.swift
+++ b/Example/Tests/StateControllerProcessUpdatesTests.swift
@@ -374,7 +374,7 @@ class StateControllerProcessUpdatesTests: XCTestCase {
         XCTAssertEqual(layout.controller.numberOfItems(in: 0, at: .beforeUpdate), 3)
         XCTAssertEqual(layout.controller.numberOfItems(in: 0, at: .afterUpdate), 4)
     }
-    
+
     func testPinnedHeader() {
         let layout = MockCollectionLayout()
         let scrollOffsetY = CGFloat(400)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@
     - [About Supplementary Views](#about-supplementary-views)
     - [About Texture](#about-texture)
     - [About animation](#about-animation)
-    - [About sticky headers or footers](#about-sticky-headers-or-footers)
 - [License](#license)
 - [Articles](#articles)
 - [Sponsor this project](#sponsor-this-project)
@@ -46,7 +45,8 @@
 - Animated insertion/deletion/reloading/moving of the items.
 - Keeps content of the last visible item at the top or bottom of the `UICollectionView` during updates.
 - Provides tools for precise scrolling to the required item.
-- Shipped with generic container views to simplify the custom items implementation.  
+- Shipped with generic container views to simplify the custom items implementation.
+- Pinned (sticky) headers and footers.
 
 ![](https://habrastorage.org/webt/jt/gq/sl/jtgqsluujffi4-jnxeikbwtyyu0.gif)
 ![](https://habrastorage.org/webt/b7/cu/3s/b7cu3su6uk4hw1kqg3_ky3uklu4.gif)
@@ -139,10 +139,6 @@ If you see a strange or unexpected animation during the updates, check your data
 It is very possible that you are sending delete/insert commands when you expect to see reload. The easiest way to check it is by adding
 `print("\(updateItems)")` into `ChatLayout.prepare(forCollectionViewUpdates:)` method. `ChatLayout` doesn't know what you expected to see. 
 It just processes your changes according to the commands it has received.
-
-### About sticky headers or footers
-
-Sticky headers or footers are not supported by `ChatLayout` but your contributions are welcome.
 
 ## License
 


### PR DESCRIPTION
## What is this PR for?
This PR introduces support for pinned (sticky) headers and footers. The implementation allows headers and footers to stay visible within the collection view's bounds.

The changes will not impact existing ChatLayout users who do not utilize the pinned feature.

Related PR: https://github.com/airbnb/MagazineLayout/pull/52

## Tests
test project: [ChatLayoutPinTest.zip](https://github.com/user-attachments/files/17523073/ChatLayoutPinTest.zip)

### 1. Scroll

https://github.com/user-attachments/assets/0e8333e0-f74c-4efb-b815-f5ff4a570710


### 2. Scroll with contentInsets
https://github.com/user-attachments/assets/3c149bc2-8f3e-4cb5-8828-9b6bb10916e6

### 3. Dynamic cell height

https://github.com/user-attachments/assets/83a620eb-e884-40dd-b662-45e9ea977594





